### PR TITLE
Create cookies and fix visual glitches

### DIFF
--- a/client/src/Pages/Account.js
+++ b/client/src/Pages/Account.js
@@ -245,7 +245,7 @@ const AccountPage = () =>
             return(
                 userData.achievements.map(({title,desc})=>{
                 return (
-                    <Achievement name={title} description={desc}/>
+                    <Achievement key={(title,desc)} name={title} description={desc}/>
                 )})
             )
         else

--- a/client/src/Pages/Account.js
+++ b/client/src/Pages/Account.js
@@ -49,8 +49,13 @@ const AccountPage = () =>
         if((process.env.JEST_WORKER_ID === undefined || process.env.NODE_ENV !== 'test'))
         {
             //check for cookie to set canLogin (stub for now)
-            setCanLogin(true);
+            const cookie = ('; '+document.cookie).split(`; user=`).pop().split(';')[0];
 
+            setCanLogin(false);
+            if(cookie===user)
+            {
+                setCanLogin(true);
+            }
             if(canLogin)
             {
                 //logged in, so get auth from backend to update the data template
@@ -106,6 +111,7 @@ const AccountPage = () =>
     function handleLogout()
     {
         //remove login cookie here
+        document.cookie = "user=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT"
         toHome();
     }
 
@@ -118,7 +124,8 @@ const AccountPage = () =>
     function doDelete()
     {
         //backend deletion go here
-        //also remove cookie
+        //remove cookie
+        document.cookie = "user=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT"
         toHome();
     }
 

--- a/client/src/Pages/Game.js
+++ b/client/src/Pages/Game.js
@@ -17,6 +17,13 @@ import data from '../TEMPDB/data';
 
 const GamePage = () =>
 {
+    const cookie = ('; '+document.cookie).split(`; user=`).pop().split(';')[0];
+    var user;
+    if(cookie.length>0)
+        user=cookie;
+    else
+        user='Guest';
+
     const [gameStatus, updateGameStatus] = React.useState({
         round: 1,
         score: 0,
@@ -63,7 +70,7 @@ const GamePage = () =>
                 score = {gameStatus.score}
                 round = {gameStatus.round}
                 maxRound = {data.length}
-                name = "Player1"
+                name = {user}
             />
             {gameStatus.gameEnd ? 
             <GameOver 

--- a/client/src/Pages/Home.js
+++ b/client/src/Pages/Home.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from "react-router-dom";
+import { useLayoutEffect } from 'react';
 import '../Styles/Home.css';
 
 // Components
@@ -7,12 +7,17 @@ import Button from '../Components/Button';
 import WordeoLogo from '../Images/WordeoLogo.png';
 
 function Home() {
+
+    useLayoutEffect(()=>{
+        document.body.style.backgroundColor = "#FFF";
+    })
+
     return (
         <div className='homepage'>
             <div className="homepageHeader">
                 <img src={WordeoLogo} alt="Wordeo Logo" />
                 <div className="signInButton">
-                <Button label="Not signed in" onClick={() => { window.location = "/account/signin" }} type="secondary" size="medium" />
+                    {loginButton()}
                 </div>
             </div>
             <div className='homepageInteractive'>
@@ -25,10 +30,27 @@ function Home() {
 
             </div>
             <div className="homepageFooter">
-                Login to save your progress and earn coins!
+                Login to save your progress!
             </div>
         </div>
     );
+}
+
+function loginButton()
+{
+    if((document.cookie.split(";").some((item) => item.trim().startsWith("user="))))
+    {
+        const cookie = ('; '+document.cookie).split(`; user=`).pop().split(';')[0];
+        return(
+                <Button label={cookie} onClick={() => { window.location = "/account/"+cookie }} type="secondary" size="medium" />
+        )
+    }
+    else
+    {
+        return(
+                <Button label="Not signed in" onClick={() => { window.location = "/account/signin" }} type="secondary" size="medium" />
+        )
+    }
 }
 
 function Play() {

--- a/client/src/Pages/Home.js
+++ b/client/src/Pages/Home.js
@@ -21,13 +21,7 @@ function Home() {
                 </div>
             </div>
             <div className='homepageInteractive'>
-                <Button label="PLAY" onClick={() => { window.location = "/game" }} type="primary" size="large" />       
-                <Button label="Leaderboards" onClick={() => { }} type="primary" size="medium" />
-                <div className='musicSFXToggle'>
-                    <Button label="Music" onClick={() => { }} type="toggles" size="medium" />
-                    <Button label="SFX" onClick={() => { }} type="toggles" size="medium" />
-                </div>
-
+                <Button label="PLAY" onClick={() => { window.location = "/game" }} type="primary" size="large" />
             </div>
             <div className="homepageFooter">
                 Login to save your progress!

--- a/client/src/Pages/SignIn.js
+++ b/client/src/Pages/SignIn.js
@@ -46,7 +46,7 @@ const SignInPage = () => {
 
             //if validated add cookie
             document.cookie = "user="+name+";domain=;path=/";
-            window.location = '/account/'+name;
+            window.location = '/';
             //otherwise update warning message
         }
     }

--- a/client/src/Pages/SignIn.js
+++ b/client/src/Pages/SignIn.js
@@ -1,6 +1,7 @@
 //the page for signing in or signing up
 
 import React from 'react';
+import { useLayoutEffect } from 'react';
 import WordeoLogo from '../Images/WordeoLogo.png';
 import '../Styles/SignIn.css';
 import '../Styles/General.css'
@@ -8,39 +9,71 @@ import Button from '../Components/Button';
 
 const SignInPage = () => {
 
+    useLayoutEffect(()=>{
+        document.body.style.backgroundColor = "#FFF";
+    })
+
     function validateSignUp()
     {
         const name = document.getElementById('upUser').value;
         const password = document.getElementById('upPass').value;
         const warning = document.getElementById('upWarning');
 
-        frontEndChecks(name,password,warning);
+        const error = frontEndChecks(name,password,warning);
 
-        //backend calls go here
-        //if successful give cookie and go to account page
-        //otherwise update warning message
+        if(!error)
+        {
+            //backend calls go here
+
+            //if validated add cookie
+            document.cookie = "user="+name+";domain=;path=/";
+            window.location = '/account/'+name;
+            //otherwise update warning message
+        }
     }
 
     function validateSignIn()
     {
-        const name = document.getElementById('inUser').value;
-        const password = document.getElementById('inPass').value;
+        const name = document.getElementById('inUser').value.trim();
+        const password = document.getElementById('inPass').value.trim();
         const warning = document.getElementById('inWarning');
 
-        frontEndChecks(name,password,warning);
+        const error = frontEndChecks(name,password,warning);
 
-        //backend calls go here
-        //if successful give cookie and go to main menu
-        //otherwise update warning message
+        if(!error)
+        {
+            //backend calls go here
+
+            //if validated add cookie
+            document.cookie = "user="+name+";domain=;path=/";
+            window.location = '/account/'+name;
+            //otherwise update warning message
+        }
     }
 
     //checks input before sending to backend
     function frontEndChecks(name,password,warning)
     {
+        var error = false;
+
         if(name.length<1)
+        {
+            error=true;    
             warning.innerHTML='Username required.';
+        }
         else if (password.length<1)
+        {
+            error=true;
             warning.innerHTML='Password required.';
+        }
+
+        if(name.toLowerCase()==='signin')
+        {
+            error=true;
+            warning.innerHTML='Invalid Username.';
+        }
+
+        return error;
     }
 
     return (
@@ -55,7 +88,7 @@ const SignInPage = () => {
                         <h1>Sign Up</h1>
                         <p id='upWarning' style={{color:'white'}}></p>
                         <input id='upUser' type='text' placeholder='username' maxLength='16' className='inputField'></input>
-                        <input id='upPass' type='text' placeholder='password' maxLength='16' className='inputField'></input>
+                        <input id='upPass' type='password' placeholder='password' maxLength='16' className='inputField'></input>
                         <Button label="Create Account" onClick={validateSignUp} type="secondary" size="medium"/>
                     </div>
                 </div>
@@ -67,7 +100,7 @@ const SignInPage = () => {
                         <h1>Sign In</h1>
                         <p id='inWarning' style={{color:'white'}}></p>
                         <input id='inUser' type='text' placeholder='username' maxLength='16' className='inputField'></input>
-                        <input id='inPass' type='text' placeholder='password' maxLength='16' className='inputField'></input>
+                        <input id='inPass' type='password' placeholder='password' maxLength='16' className='inputField'></input>
                         <Button label="Login" onClick={validateSignIn} type="secondary" size="medium"/>
                     </div>
                 </div>

--- a/client/src/Tests/Home.test.js
+++ b/client/src/Tests/Home.test.js
@@ -3,7 +3,7 @@ import Home from '../Pages/Home';
 
 test('Check if Home page renders tip', () => {
   render(<Home />);
-  const tipText = screen.getByText(/Login to save your progress and earn coins!/i);
+  const tipText = screen.getByText(/Login to save your progress!/i);
   expect(tipText).toBeInTheDocument();
 });
 
@@ -20,6 +20,5 @@ test('Check if Home page renders Sign In button', () => {
 });
 
 // Potential tests:
-// Sign in Button after signing in should be updated to say "Account"
 // PLAY button should redirect to game page
 // Sign in button should redirect to sign in page


### PR DESCRIPTION
Add cookie functionality to sign in and account page.  Name of the logged in user will also display on the main menu and in the game (if not logged in during game it says 'Guest').  Attempting to access an account route without matching login cookie will redirect to the sign in page (you cannot access any account page you are not logged into).
Currently no backend validation, so putting anything in the sign in/sign up box works.

Also fixed visual oddities: background colour sometimes not retained on page switch, password input on sign in is now censored.